### PR TITLE
Fix resource_update to handle path property in resources as url

### DIFF
--- a/dpckan/resource_create.py
+++ b/dpckan/resource_create.py
@@ -25,24 +25,6 @@ import ipdb
 @click.option('--resource-name', '-rn', required=True,
               help="Nome do recurso a ser incluído. Chave 'name' do recurso dentro do arquivo datapackage.json")
 def resource_upload(ckan_host, ckan_key, package_id, resource_name):
-  """
-  Summary line.
-
-  Extended description of function.
-
-  Parameters
-  ----------
-  arg1 : int
-      Description of arg1
-  arg2 : str
-      Description of arg2
-
-  Returns
-  -------
-  int
-      Description of return value
-
-  """
   # try:
   datapackage_path = f'.{os_slash}datapackage.json'
   package = load_complete_datapackage(datapackage_path)
@@ -59,8 +41,7 @@ def resource_upload(ckan_host, ckan_key, package_id, resource_name):
                                   package.get_resource(resource_name)["description"],
                                   package.get_resource(resource_name).title)
   resources_metadata_create(ckan_host,
-                            package,
+                            ckan_key,
                             resource_ckan['id'],
-                            package.get_resource(resource_name).path,
-                            ckan_key)
+                            package.get_resource(resource_name))
 

--- a/dpckan/updateResource.py
+++ b/dpckan/updateResource.py
@@ -56,7 +56,6 @@ def resource_update_cli(ckan_host, ckan_key, package_id, resource_name, resource
                   resource_id,
                   package.get_resource(resource_name).path)
   resources_metadata_create(ckan_host,
-                            package,
+                            ckan_key,
                             resource_id,
-                            package.get_resource(resource_name).path,
-                            ckan_key)
+                            package.get_resource(resource_name))


### PR DESCRIPTION
In order to property load urls paths to datastore it was necessary to refactor the resources_metadata_create() logic of determining which resource should be updated in ckan

Fix #46