### PR TITLE
Change resource_create arguments to receive full data package resource

### DIFF
--- a/dpckan/resource_create.py
+++ b/dpckan/resource_create.py
@@ -36,10 +36,7 @@ def resource_upload(ckan_host, ckan_key, package_id, resource_name):
   resource_ckan = resource_create(ckan_host,
                                   ckan_key,
                                   package_id,
-                                  package.get_resource(resource_name).path,
-                                  # Put resource description key to show only this description resource's page
-                                  package.get_resource(resource_name)["description"],
-                                  package.get_resource(resource_name).title)
+                                  package.get_resource(resource_name))
   resources_metadata_create(ckan_host,
                             ckan_key,
                             resource_ckan['id'],


### PR DESCRIPTION
Instead of passing individual arguments to resource_create, it is a better approach to pass the entire resource metadata so that the function could better evolve in the future.

Resolves #48