### PR TITLE
Refatora funções que fazem leitura direta do datapackage.json

### DIFF
--- a/dpckan/create_dataset.py
+++ b/dpckan/create_dataset.py
@@ -1,11 +1,11 @@
-import json
 import click
 from ckanapi import RemoteCKAN
 from dpckan.validations import run_validations
-from dpckan.functions import (frictionless_to_ckan_dictionary,
-                              delete_dataset, 
+from dpckan.functions import (delete_dataset, 
                               dataset_create,
-                              is_dataset_alread_published)
+                              is_dataset_alread_published,
+                              load_complete_datapackage)
+                              
 
 @click.command()
 @click.option('--ckan-host', '-H', envvar='CKAN_HOST', required=True,
@@ -32,15 +32,16 @@ def create(ckan_host, ckan_key, datapackage):
   -------
     Dataset publicado/atualizado no ambiente desejado
   """
-  run_validations(ckan_host, ckan_key)
-  dataset_dict = json.loads(frictionless_to_ckan_dictionary(datapackage))
-  published_dataset = is_dataset_alread_published(ckan_host, dataset_dict['name'])
+  
+  package = load_complete_datapackage(datapackage)
+  run_validations(ckan_host, ckan_key, package)
+  published_dataset = is_dataset_alread_published(ckan_host, package.name)
   
   ckan_instance = RemoteCKAN(ckan_host, apikey = ckan_key)
 
   if published_dataset:
     # Deleting dataset if it exists
-    delete_dataset(ckan_instance, dataset_dict['name'])
+    delete_dataset(ckan_instance, package.name)
   
-  dataset_create(ckan_instance)
+  dataset_create(ckan_instance, package)
   

--- a/dpckan/create_resource.py
+++ b/dpckan/create_resource.py
@@ -21,7 +21,7 @@ def create_resource(ckan_host, ckan_key, datapackage, resource_name):
   # Update datapakcage.json resource
   ckan_instance = RemoteCKAN(ckan_host, apikey = ckan_key)
   
-  update_datapackage_json_resource(ckan_instance, package.name)
+  update_datapackage_json_resource(ckan_instance, package)
   # Create new resource
   print(f"Criando recurso: {resource_name}")
   resource_ckan = resource_create(ckan_instance,

--- a/dpckan/update_resource.py
+++ b/dpckan/update_resource.py
@@ -38,7 +38,7 @@ def update_resource(ckan_host, ckan_key, datapackage, resource_name, resource_id
   ckan_instance = RemoteCKAN(ckan_host, apikey = ckan_key)
   # Show package to find datapackage.json resource id
   # Update datapakcage.json resource
-  update_datapackage_json_resource(ckan_instance, package.name)
+  update_datapackage_json_resource(ckan_instance, package)
   resource_update(ckan_instance,
                   resource_id,
                   package.get_resource(resource_name))

--- a/dpckan/validations.py
+++ b/dpckan/validations.py
@@ -1,14 +1,13 @@
-import os
 import json
 import sys
 import click
 from ckanapi import RemoteCKAN
 
-def run_validations(host, key):
+def run_validations(host, key, datapackage):
   """
     Run validations before dataset publication
   """
-  is_datapackage_present()
+  is_datapackage_present(datapackage)
   is_host_valid(host)
 
 def is_host_valid(host):
@@ -18,7 +17,7 @@ def is_host_valid(host):
   except:
     sys.exit(1)
 
-def is_datapackage_present():
+def is_datapackage_present(datapackage):
   """
   Verifica a existência da chave "datapackage_resource_id" no arquivo datapackage.json para o ambiente desejado (homologação ou produção)
   Existência da chave "datapackage_resource_id" significa que pacote já foi publicado no ambiente desejado
@@ -41,22 +40,14 @@ def is_datapackage_present():
   None
     quando a chave não existir
   """
-  try:
-    with open('datapackage.json','r', encoding="utf-8") as json_file:
-      datapackage_keys = json.load(json_file)
-      if f"name" in datapackage_keys.keys():
-        pass
-      else:
-        click.echo("----Arquivo datapackage.json sem a chave 'name' obrigatória----")
-        sys.exit(1)
-      if f"resources" in datapackage_keys.keys():
-        pass
-      else:
-        click.echo("----Arquivo datapackage.json sem a chave 'resources' obrigatória----")
-        sys.exit(1)
-  except FileNotFoundError:
-    click.echo("----Arquivo datapackage.json não encontrado na raiz do dataset----")
+  if f"name" in datapackage.keys():
+    pass
+  else:
+    click.echo("----Arquivo datapackage.json sem a chave 'name' obrigatória----")
     sys.exit(1)
-  except json.decoder.JSONDecodeError:
-    click.echo("----Arquivo datapackage.json com algum problema de sintaxe ou em branco----")
+  if f"resources" in datapackage.keys():
+    pass
+  else:
+    click.echo("----Arquivo datapackage.json sem a chave 'resources' obrigatória----")
     sys.exit(1)
+


### PR DESCRIPTION
Com essa as funções internas deixam de fazer a leitura direta do arquivo datapackage.json
e esperam receber um objeto datapackage que possui os metadados necessários.

O principal benefício dessa refatoração é que já passa a ser possível publicar
data packages que não estão no diretório ativo do terminal. Ou seja,
os comandos abaixo funcionam

```
dpckan create -dp datapackage-reprex/datapackage.json
dpckan create-resource -dp datapackage-reprex/datapackage.json -n minimal
dpckan update-resource -dp datapackage-reprex/datapackage.json -n data-types -id fccc0400-c1fb-4486-811e-810a9ddf7bb4
```

Resolves #60