### PR TITLE
Use dict.get to access optional schema properties

### DIFF
--- a/dpckan/functions.py
+++ b/dpckan/functions.py
@@ -70,7 +70,7 @@ def resources_metadata_create(ckan_instance, resource_id, resource):
   dataset_fields.update(force)
   fields = []
   for field in resource.schema.fields:
-    meta_info = {"label": field["title"], "notes" : field["description"] , "type_override" : 'text' }
+    meta_info = {"label": field.get("title", ""), "notes" : field.get("description", "") , "type_override" : 'text' }
     field = { "type" : 'text', "id" : field["name"] , "info" : meta_info }
     fields.append(field)
   dataset_fields.update({ "fields" : fields})


### PR DESCRIPTION
With dict.get is possible to provide a default value if the key is missing

```
dict.get("key", 'default_value')
```

preventing KeyError problems.

## Links

- [Python: most idiomatic way to convert None to empty string?](https://stackoverflow.com/questions/1034573/python-most-idiomatic-way-to-convert-none-to-empty-string)
- [Why dict.get(key) instead of dict[key]?](https://stackoverflow.com/questions/11041405/why-dict-getkey-instead-of-dictkey)

Resolves #65